### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/Xu929-X1/mini-nest/security/code-scanning/1](https://github.com/Xu929-X1/mini-nest/security/code-scanning/1)

To fix this, add an explicit `permissions` block to the workflow with the least privilege needed.  
Best single change without altering functionality: set workflow-level permissions to `contents: read` right after the `on` section (or near the top-level keys). This applies to all jobs unless overridden and is sufficient for checkout/build/test.

**File to edit:** `.github/workflows/CI.yml`  
**Change:** Insert:

```yml
permissions:
  contents: read
```

No imports, methods, or dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
